### PR TITLE
Fix link to live blog in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ tags:
 
 (only `title`, `slug` and `date` are necessary).
 
-The [live site](https://royaloperahouse.github.io/) is automatically updated when you make changes in GitHub.
+The [live site](https://royaloperahouse.github.io/digital-blog/) is automatically updated when you make changes in GitHub.
 
 ### Adding images
 


### PR DESCRIPTION
Fixed the link to the live site in README.md which was previously leading to a 404