### PR TITLE
Update baseurl in config.toml

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,4 @@
-baseURL = "/"
+baseURL = "https://royaloperahouse.github.io/digital-blog"
 languageCode = "en-gb"
 title = "ROH Digital blog"
 theme = "hugo-tailwind-journal-master"


### PR DESCRIPTION
The baseurl in config.toml was set to "/" which meant that the site ran fine locally but the URLs were wrong after deployment, pointing to the repo, rather than the github pages space. I updated it to "https://royaloperahouse.github.io/digital-blog" as per the instructions here: https://gohugo.io/hosting-and-deployment/hosting-on-github/